### PR TITLE
Handle removed options on frontend and option to limit who can add options.

### DIFF
--- a/service/model/voteTypes.ts
+++ b/service/model/voteTypes.ts
@@ -26,6 +26,7 @@ export interface BaseModOptions { // options that apply to all vote types (eg. r
   numRunnerUps: number
   showNumVotes: boolean
   showWhoVoted: boolean
+  allowNewOptions: boolean
 
   // Multi-round voting options
   enableRound?: boolean        // Whether to enable multi-round voting

--- a/service/peerProxy.ts
+++ b/service/peerProxy.ts
@@ -163,6 +163,10 @@ class PeerProxy {
       console.warn(`room does not include user ${connection.user}`)
       return
     }
+    if (!room.config.options.allowNewOptions && room.owner !== connection.user) {
+      console.warn(`user is not room owner`);
+      return
+    }
 
     const newOption = event.option
     if (room.options.map(opt => opt.toLowerCase()).includes(newOption.toLowerCase())) {

--- a/src/pages/new/new.jsx
+++ b/src/pages/new/new.jsx
@@ -310,6 +310,17 @@ export default function New() {
                   Show Who Voted
                 </label>
               </div>
+
+              <div className="checkbox-row">
+                <label>
+                  <input
+                      type="checkbox"
+                      checked={config.options.allowNewOptions}
+                      onChange={(e) => handleCommonOptionChange('allowNewOptions', e.target.checked)}
+                  />
+                  Allow Room Participants to Add Options
+                </label>
+              </div>
             </div>
 
             <div className="option-group">

--- a/src/pages/vote/vote.jsx
+++ b/src/pages/vote/vote.jsx
@@ -349,7 +349,9 @@ export default function Vote() {
         <ul className="vote-options">
           {renderOptions()}
         </ul>
-        <AddOption onSubmit={addOption} disabled={lockedIn || waitingForNextRound} />
+        {config.options && (config.options.allowNewOptions || isRoomOwner) &&
+          (<AddOption onSubmit={addOption} disabled={lockedIn || waitingForNextRound} />)
+        }
         {renderButton()}
       </main>
       <ShareModal

--- a/src/pages/vote/voteTypes/quadratic.jsx
+++ b/src/pages/vote/voteTypes/quadratic.jsx
@@ -29,7 +29,7 @@ export default function QuadraticVote({ config, options, vote, setVote, disabled
             });
             setRemainingCredits(creditBudget);
         } else {            
-            // Filter out deleted otpions from votes and costs
+            // Filter out deleted options from votes and costs
             const filteredVotes = Object.fromEntries(
                 Object.entries(vote.votes || {}).filter(([option]) => options.includes(option))
             );

--- a/src/pages/vote/voteTypes/quadratic.jsx
+++ b/src/pages/vote/voteTypes/quadratic.jsx
@@ -28,10 +28,23 @@ export default function QuadraticVote({ config, options, vote, setVote, disabled
                 costs: {}
             });
             setRemainingCredits(creditBudget);
-        } else {
+        } else {            
+            // Filter out deleted otpions from votes and costs
+            const filteredVotes = Object.fromEntries(
+                Object.entries(vote.votes || {}).filter(([option]) => options.includes(option))
+            );
+            const filteredCosts = Object.fromEntries(
+                Object.entries(vote.costs || {}).filter(([option]) => options.includes(option))
+            );
+
+            setVote({
+                votes: filteredVotes,
+                costs: filteredCosts
+            });
+
             // Calculate remaining credits
             let usedCredits = 0;
-            Object.values(vote.costs || {}).forEach(cost => {
+            Object.values(filteredCosts || {}).forEach(cost => {
                 usedCredits += cost;
             });
             setRemainingCredits(creditBudget - usedCredits);

--- a/src/pages/vote/voteTypes/topChoices.jsx
+++ b/src/pages/vote/voteTypes/topChoices.jsx
@@ -63,7 +63,7 @@ export default function TopChoicesVote({ config, options, vote, setVote, disable
     useEffect(() => {
         if (selections) {
             const filteredSelections = Object.fromEntries(
-                Object.entries(selections).filter(([key, value]) => options.includes(value))
+                Object.entries(selections).filter(([_, value]) => options.includes(value))
             );
             setSelections(filteredSelections);
         }

--- a/src/pages/vote/voteTypes/topChoices.jsx
+++ b/src/pages/vote/voteTypes/topChoices.jsx
@@ -59,6 +59,16 @@ export default function TopChoicesVote({ config, options, vote, setVote, disable
         }
     }, [selections]);
 
+    // Handle a removed vote
+    useEffect(() => {
+        if (selections) {
+            const filteredSelections = Object.fromEntries(
+                Object.entries(selections).filter(([key, value]) => options.includes(value))
+            );
+            setSelections(filteredSelections);
+        }
+    }, [options])
+
     const handleSelection = (option, position) => {
         if (disabled) return;
 

--- a/src/pages/vote/voteTypes/topChoices.jsx
+++ b/src/pages/vote/voteTypes/topChoices.jsx
@@ -63,7 +63,7 @@ export default function TopChoicesVote({ config, options, vote, setVote, disable
     useEffect(() => {
         if (selections) {
             const filteredSelections = Object.fromEntries(
-                Object.entries(selections).filter(([_, value]) => options.includes(value))
+                Object.entries(selections).filter(([, value]) => options.includes(value))
             );
             setSelections(filteredSelections);
         }


### PR DESCRIPTION
One commit is to add a configuration option to rooms which would only allow room owners to add new options.

The second commit is to more robustly handle an option being removed on the frontend. 

- In the quadratic voting, the available credits is now correctly updated when an option is removed.
- In the top choices voting, a removed option is now properly removed from the users' selected votes when applicable.

The other 2 commits were just me trying to make lint happy with how I filter the selections.