### PR TITLE
fix vote page reload

### DIFF
--- a/service/database/RoomDAO.ts
+++ b/service/database/RoomDAO.ts
@@ -11,11 +11,11 @@ export interface RoomDAO {
   removeOptionFromRoom: (roomId: string, option: string) => Promise<boolean>,
   submitUserVotes: (roomId: string, username: string, vote: Vote) => Promise<boolean>,
   removeUserVotes: (roomId: string, username: string) => Promise<void>,
-  closeRoom: (roomId: string) => Promise<boolean>,
+  closeRoom: (roomId: string, resultId: string) => Promise<boolean>,
   deleteRoom: (roomId: string) => Promise<boolean>,
 
   // Multi-round voting methods
-  completeRound: (roomId: string) => Promise<{eliminatedOptions: string[], remainingOptions: string[], roundNumber: number} | null>,
+  completeRound: (roomId: string) => Promise<{ eliminatedOptions: string[], remainingOptions: string[], roundNumber: number } | null>,
   advanceToNextRound: (roomId: string, remainingOptions: string[]) => Promise<boolean>,
   getCurrentRound: (roomId: string) => Promise<number>,
   getRoundHistory: (roomId: string) => Promise<Room['roundHistory'] | undefined>

--- a/service/index.ts
+++ b/service/index.ts
@@ -135,14 +135,17 @@ async function main() {
       return
     }
 
-    if (room.state !== 'open') {
-      res.status(409).send({ msg: 'Room is not open' })
-      return
-    }
-
     await roomDAO.addParticipantToRoom(room.code, user.username);
 
-    res.status(200).send({ ...room, isOwner: room.owner === user.username })
+    const currentVote = room.votes.find(uv => uv.username === user.username)?.vote
+    const lockedIn = currentVote !== undefined;
+
+    res.status(200).send({
+      ...room,
+      isOwner: room.owner === user.username,
+      lockedIn,
+      currentVote
+    })
   })
 
   anonymousApiRouter.post('/room/:code/join', async (req: Request, res: Response) => {
@@ -197,7 +200,7 @@ async function main() {
       return
     }
 
-    res.status(200).send({ results: result.sortedOptions, totals: result.sortedTotals, users: result.sortedUsers, usersVotes: result.sortedUsersVotes})
+    res.status(200).send({ results: result.sortedOptions, totals: result.sortedTotals, users: result.sortedUsers, usersVotes: result.sortedUsersVotes })
   })
 
   secureApiRouter.get('/history', async (req: Request, res: Response) => {

--- a/service/model/index.ts
+++ b/service/model/index.ts
@@ -20,6 +20,7 @@ export interface Room {
   options: string[]
   votes: UserVote[]
   config: VoteConfig
+  resultId: string
 
   // ROUND STUFF
   currentRound?: number

--- a/service/peerProxy.ts
+++ b/service/peerProxy.ts
@@ -441,11 +441,12 @@ class PeerProxy {
   }
 
   private async closeRoom(room: WithId<Room>): Promise<WithId<Result>> {
-    await this.roomDAO.closeRoom(room._id.toHexString());
-
     const aggregator = aggregationMap[room.config.type]
     const result = aggregator(room)
-    return await this.historyDAO.createResult(result.owner, result.sortedOptions, result.sortedTotals, result.sortedUsers, result.sortedUsersVotes);
+    const storedResult = await this.historyDAO.createResult(result.owner, result.sortedOptions, result.sortedTotals, result.sortedUsers, result.sortedUsersVotes);
+
+    await this.roomDAO.closeRoom(room._id.toHexString(), storedResult._id.toHexString());
+    return storedResult
   }
 }
 

--- a/src/pages/vote/vote.jsx
+++ b/src/pages/vote/vote.jsx
@@ -81,6 +81,11 @@ export default function Vote() {
         setConfig(body.config)
         setOptions(body.options)
         setIsRoomOwner(body.isOwner)
+        setLockedIn(body.lockedIn)
+        if (body.currentVote) {
+          setVote(body.currentVote)
+        }
+        setResultsId(body.resultId)
 
         // Initialize round state
         if (body.config?.options?.enableRound) {


### PR DESCRIPTION
Previously, reloading the vote page would show an inaccurate state if the user was already locked in or if the room was closed. Now, if the user was already locked in, then a reload will show them as locked in and show their locked in vote. If the room is closed, then a reload will show them the "view results" button.