### PR TITLE
feat: add option and action button stay at the bottom of the screen

### DIFF
--- a/src/pages/new/new.css
+++ b/src/pages/new/new.css
@@ -306,7 +306,6 @@ input:checked + .slider:before {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 15px 0;
   padding: 10px;
   background-color: #f1f8ff;
   border-radius: 6px;
@@ -357,7 +356,7 @@ input:checked + .slider:before {
 
 /* Round results summary */
 .round-results-summary {
-  margin-top: 20px;
+  margin-bottom: 20px;
   padding: 15px;
   background-color: #f8f9fa;
   border-radius: 6px;

--- a/src/pages/vote/vote.css
+++ b/src/pages/vote/vote.css
@@ -29,9 +29,12 @@
   opacity: 1;
 }
 
-.vote-options {
+.vote-content {
   flex-grow: 1;
   overflow-y: auto;
+}
+
+.vote-options {
   list-style: none;
   padding: 0;
 }
@@ -141,7 +144,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 20px;
   padding: 15px;
   background-color: #f8fafc;
   border-radius: 10px;

--- a/src/pages/vote/vote.css
+++ b/src/pages/vote/vote.css
@@ -30,9 +30,10 @@
 }
 
 .vote-options {
+  flex-grow: 1;
+  overflow-y: auto;
   list-style: none;
   padding: 0;
-  margin-bottom: 20px;
 }
 
 .vote-options__item {
@@ -85,7 +86,6 @@
 .add-option {
   display: flex;
   justify-content: center;
-  margin-bottom: 20px;
 }
 
 .add-option__input {
@@ -158,7 +158,8 @@
 }
 
 .preliminary-badge {
-  background-color: #f59e0b;  /* Amber/orangy-yellow color */
+  background-color: #f59e0b;
+  /* Amber/orangy-yellow color */
 }
 
 .round-status {
@@ -247,11 +248,12 @@
 }
 
 @keyframes slideDown {
-  from { 
+  from {
     transform: translate(-50%, -20px);
     opacity: 0;
   }
-  to { 
+
+  to {
     transform: translate(-50%, 0);
     opacity: 1;
   }
@@ -277,7 +279,8 @@
 
 /* Preliminary round instructions */
 .preliminary-instructions {
-  background-color: #fef3c7;  /* Light yellow background */
+  background-color: #fef3c7;
+  /* Light yellow background */
   border: 1px solid #fbbf24;
   border-radius: 8px;
   padding: 15px;

--- a/src/pages/vote/vote.jsx
+++ b/src/pages/vote/vote.jsx
@@ -463,11 +463,13 @@ export default function Vote() {
       {alert.show && <AlertNotification />}
       <main className="main" id="main-element">
         {renderRoundIndicator()}
-        {renderPreviousRoundResults()}
 
-        <ul className="vote-options">
-          {renderOptions()}
-        </ul>
+        <div className="vote-content">
+          {renderPreviousRoundResults()}
+          <ul className="vote-options">
+            {renderOptions()}
+          </ul>
+        </div>
         {/* Determine whether to show add option based on room state and config */}
         {((roomState === 'preliminary' && config.options && 
              (config.options.allowNewOptions === 'everyone' || 

--- a/src/pages/vote/vote.jsx
+++ b/src/pages/vote/vote.jsx
@@ -465,14 +465,6 @@ export default function Vote() {
         {renderRoundIndicator()}
         {renderPreviousRoundResults()}
 
-        {roomState === 'preliminary' && (
-          <div className="preliminary-instructions">
-            <h3>Preliminary Round</h3>
-            <p>This is the option gathering phase. All participants can add options based on the room settings.</p>
-            <p>Voting is disabled during this phase. When the room owner ends the preliminary round, voting will begin and only the room owner will be able to add new options.</p>
-          </div>
-        )}
-        
         <ul className="vote-options">
           {renderOptions()}
         </ul>


### PR DESCRIPTION
Pushes the add option and action button to the bottom of the vote screen, and also adds a scroll bar for the vote options.

<img width="183" alt="image" src="https://github.com/user-attachments/assets/aafd7998-9fab-46d3-9403-88b43fa92c8d" />
<img width="181" alt="image" src="https://github.com/user-attachments/assets/8d63e6bf-1906-4cfc-90f4-9a2fc8c8a053" />

Also gets rid of some extra preliminary round notes. They take up a lot of space on mobile and I think they may not be necessary. There is still a "round indicator" for the preliminary round that has sufficient instructions I think. I can put it back if it's deemed necessary though.